### PR TITLE
GlassCase horizontal alignment

### DIFF
--- a/src/components/sections/Families/GlassCase.tsx
+++ b/src/components/sections/Families/GlassCase.tsx
@@ -27,10 +27,12 @@ export default function GlassCase(): ReactElement {
           lasting memories.
         </span>
       </div>
-      <div className="d-flex flex-row w-100 justify-content-center mt-5 scrolling-wrapper-flexbox">
-        {CARDS.map((card) => (
-          <GlassCaseCard name={card.name} image={card.image} />
-        ))}
+      <div className="d-flex w-100 justify-content-center">
+        <div className="d-flex flex-row mt-5 scrolling-wrapper-flexbox">
+          {CARDS.map((card) => (
+            <GlassCaseCard name={card.name} image={card.image} />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/Families/GlassCase.tsx
+++ b/src/components/sections/Families/GlassCase.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import GlassCaseCard, {
   GlassCaseCardProps,
 } from "src/components/cards/GlassCaseCard";
@@ -16,9 +16,20 @@ export default function GlassCase(): ReactElement {
     { name: "Beautiful", image: Scenery },
     { name: "Fun", image: Game },
   ];
+  
+  const scroller = React.createRef();
+  const scrollToCenter = () => {
+    const element = scroller.current;
+    element.scrollLeft = (element.scrollWidth - element.offsetWidth) / 2;
+  }
+
+  useEffect(() => {
+    scrollToCenter();
+  });
+
   return (
     <section className="d-flex blue-200-bg flex-column align-items-center py-5">
-      <div className="d-flex flex-column justify-content-center text-center px-3">
+      <div className="d-flex flex-column justify-content-center text-center px-3" ref={scroller}>
         <span className="dark p2 font-weight-bold">
           Always stay close, no matter the distance.
         </span>


### PR DESCRIPTION
## What?

I updated the `GlassCase` ReactElement template and Tailwind classes to allow the element to be scrolled all the way to the left. I added JavaScript to scroll the content to the center to retain the look achieved by the previous version.

## Why?

The `GlassCase` ReactElement is used on the homepage to feature mailing examples (Cartoons, Quotes, Special, Beautiful, Fun). It cannot be scrolled all the way to the left if its content is wider than the viewport, so the first 1-2 examples are not accessible to users with narrow viewports.

## How?

I improved the scrolling by wrapping the container in a parent flexbox container, and moving the width and center justification styling to the parent flexbox. This way, the center justification does not interfere with the overflow styling.

I added a JavaScript function with `useEffect` to initially scroll the content to the center when the element is rendered.

## Other thoughts

I'm not sure if the original intention was for the content to be initially centered on narrow viewports (i.e. for the "Special" mailing to be initially more prominent than the "Cartoons" mailing). If this is not the intention, the JavaScript may not be necessary, and commit d408d33 could be reverted.

## Screenshots

Before these updates, the component is centered but cannot scroll any further to the left. The first 1-2 elements are not accessible (depending on viewport width):

![image](https://user-images.githubusercontent.com/5807170/124706410-30961d80-dec5-11eb-80f6-9fc01a25411e.png)

With these updates, the component starts in the same centered position, but you can scroll all the way to the left:

![image](https://user-images.githubusercontent.com/5807170/124706430-3d1a7600-dec5-11eb-97c8-973e7336fd80.png)
